### PR TITLE
config accessors types have been changed  to URIO

### DIFF
--- a/src/main/scala/com/zio/examples/http4s_doobie/configuration/package.scala
+++ b/src/main/scala/com/zio/examples/http4s_doobie/configuration/package.scala
@@ -15,8 +15,8 @@ package object configuration {
       password: String
   )
 
-  val apiConfig: ZIO[Has[ApiConfig], Throwable, ApiConfig] = ZIO.access(_.get)
-  val dbConfig: ZIO[Has[DbConfig], Throwable, DbConfig] = ZIO.access(_.get)
+  val apiConfig: URIO[Has[ApiConfig], ApiConfig] = ZIO.access(_.get)
+  val dbConfig:  URIO[Has[DbConfig],  DbConfig]  = ZIO.access(_.get)
 
   object Configuration {
     import pureconfig.generic.auto._


### PR DESCRIPTION
At first look it is not clear why accessing to environment can cause error. Figuring out what the reason was behind can be confusing for newcomers