### PR TITLE
removed connection EC passing as parameter

### DIFF
--- a/src/main/scala/com/zio/examples/http4s_doobie/Main.scala
+++ b/src/main/scala/com/zio/examples/http4s_doobie/Main.scala
@@ -27,7 +27,7 @@ object Main extends App {
   type AppTask[A] = RIO[AppEnvironment, A]
 
   val userPersistence = (Configuration.live ++ Blocking.live) >>> UserPersistenceService
-    .live(platform.executor.asEC)
+    .live
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, Int] = {
     val program: ZIO[AppEnvironment, Throwable, Unit] =

--- a/src/main/scala/com/zio/examples/http4s_doobie/persistence/UserPersistenceService.scala
+++ b/src/main/scala/com/zio/examples/http4s_doobie/persistence/UserPersistenceService.scala
@@ -79,10 +79,11 @@ object UserPersistenceService {
       .map(new UserPersistenceService(_))
   }
 
-  def live(connectEC: ExecutionContext): ZLayer[Has[DbConfig] with Blocking, Throwable, UserPersistence] =
+  def live: ZLayer[Has[DbConfig] with Blocking, Throwable, UserPersistence] =
     ZLayer.fromManaged (
       for {
         config <- configuration.dbConfig.toManaged_
+        connectEC  <- ZIO.descriptor.map(_.executor.asEC).toManaged_
         blockingEC <- blocking.blocking { ZIO.descriptor.map(_.executor.asEC) }.toManaged_
         managed <- mkTransactor(config, connectEC, blockingEC)
       } yield managed

--- a/src/test/scala/com/zio/examples/http4s_doobie/persistence/UserPersistenceSpec.scala
+++ b/src/test/scala/com/zio/examples/http4s_doobie/persistence/UserPersistenceSpec.scala
@@ -8,8 +8,6 @@ import zio.test.environment.TestEnvironment
 import zio.{Cause, ZLayer}
 
 object UserPersistenceSpec extends DefaultRunnableSpec {
-  val ec = concurrent.ExecutionContext.global
-
   val dbConfig = ZLayer.succeed(DbConfig("jdbc:h2:~/test", "", ""))
 
   def spec =
@@ -24,7 +22,7 @@ object UserPersistenceSpec extends DefaultRunnableSpec {
           assert(deleted)(isRight(isTrue))
     }).provideSomeLayer[TestEnvironment](
       (dbConfig ++ Blocking.live) >>> UserPersistenceService
-        .live(ec)
+        .live
         .mapError(_ => TestFailure.Runtime(Cause.die(new Exception("die")))))
 
 }


### PR DESCRIPTION
I haven't found what the main idea was behind passing EC for connections as parameter, but it's possible that I've missed something. If expressing EC as param is not matter I think I will be better to omit it. That will help for newcomers to concentrate on other details.